### PR TITLE
fixed grant types available scopes

### DIFF
--- a/spec/OAuth2/GrantType/AuthorizationCodeSpec.php
+++ b/spec/OAuth2/GrantType/AuthorizationCodeSpec.php
@@ -180,7 +180,7 @@ class AuthorizationCodeSpec extends ObjectBehavior
         $client->isAllowedToUse($this)->willReturn(true)->shouldBeCalled();
         $client->getRedirectUri()->willReturn('http://google.sk')->shouldBeCalled();
         $request->query('scope')->willReturn(null)->shouldBeCalled();
-        $client->getScopes()->willReturn([])->shouldBeCalled();
+        $user->getScopes()->willReturn([])->shouldBeCalled();
         $scopeResolver->getDefaultScopes()->willReturn([])->shouldBeCalled();
 
         $this
@@ -206,7 +206,7 @@ class AuthorizationCodeSpec extends ObjectBehavior
         $client->getRedirectUri()->willReturn('http://google.sk')->shouldBeCalled();
         $request->query('state')->willReturn('test')->shouldBeCalled();
         $request->query('scope')->willReturn(null)->shouldBeCalled();
-        $client->getScopes()->willReturn([$scope])->shouldBeCalled();
+        $user->getScopes()->willReturn([$scope])->shouldBeCalled();
         $scopeResolver->intersect(null, [$scope])->willReturn([$scope])->shouldBeCalled();
         $authorizationCodeStorage
             ->generate($user, $client, [$scope], 'http://google.sk', 'test')

--- a/spec/OAuth2/GrantType/ImplicitSpec.php
+++ b/spec/OAuth2/GrantType/ImplicitSpec.php
@@ -170,7 +170,7 @@ class ImplicitSpec extends ObjectBehavior
         $request->query('redirect_uri')->willReturn(null)->shouldBeCalled();
         $client->getRedirectUri()->willReturn('http://google.sk')->shouldBeCalled();
         $request->query('scope')->willReturn(null)->shouldBeCalled();
-        $client->getScopes()->willReturn([])->shouldBeCalled();
+        $user->getScopes()->willReturn([])->shouldBeCalled();
         $scopeResolver->getDefaultScopes()->willReturn([])->shouldBeCalled();
 
         $this
@@ -195,7 +195,7 @@ class ImplicitSpec extends ObjectBehavior
         $request->query('redirect_uri')->willReturn('http://google.com')->shouldBeCalled();
         $client->getRedirectUri()->willReturn('http://google.com')->shouldBeCalled();
         $request->query('scope')->willReturn('scope1')->shouldBeCalled();
-        $client->getScopes()->willReturn([])->shouldBeCalled();
+        $user->getScopes()->willReturn([])->shouldBeCalled();
         $scopeResolver->getDefaultScopes()->willReturn([$scope])->shouldBeCalled();
         $scopeResolver->intersect('scope1', [$scope])->willReturn([$scope])->shouldBeCalled();
         $request->query('state')->willReturn(null)->shouldBeCalled();

--- a/spec/OAuth2/GrantType/ResourceOwnerPasswordCredentialsSpec.php
+++ b/spec/OAuth2/GrantType/ResourceOwnerPasswordCredentialsSpec.php
@@ -111,7 +111,7 @@ class ResourceOwnerPasswordCredentialsSpec extends ObjectBehavior
         $client->isAllowedToUse($this)->willReturn(true)->shouldBeCalled();
         $userAuthenticator->authenticate('root', 'p')->willReturn($user)->shouldBeCalled();
         $request->request('scope')->shouldBeCalled();
-        $client->getScopes()->willReturn([])->shouldBeCalled();
+        $user->getScopes()->willReturn([])->shouldBeCalled();
         $scopeResolver->getDefaultScopes()->willReturn([])->shouldBeCalled();
 
         $this
@@ -120,7 +120,7 @@ class ResourceOwnerPasswordCredentialsSpec extends ObjectBehavior
     }
 
 
-    function it_issues_an_access_token_using_client_scopes(
+    function it_issues_an_access_token_using_user_scopes(
         IRequest $request,
         IClientAuthenticator $clientAuthenticator,
         IUserAuthenticator $userAuthenticator,
@@ -137,7 +137,7 @@ class ResourceOwnerPasswordCredentialsSpec extends ObjectBehavior
         $client->isAllowedToUse($this)->willReturn(true)->shouldBeCalled();
         $userAuthenticator->authenticate('root', 'p')->willReturn($user)->shouldBeCalled();
         $request->request('scope')->willReturn(null)->shouldBeCalled();
-        $client->getScopes()->willReturn([$scope])->shouldBeCalled();
+        $user->getScopes()->willReturn([$scope])->shouldBeCalled();
         $scopeResolver->getDefaultScopes()->shouldNotBeCalled();
         $scopeResolver->intersect(null, [$scope])->willReturn([$scope])->shouldBeCalled();
         $accessTokenStorage->generate($user, $client, [$scope])->willReturn($accessToken)->shouldBeCalled();
@@ -163,7 +163,7 @@ class ResourceOwnerPasswordCredentialsSpec extends ObjectBehavior
         $client->isAllowedToUse($this)->willReturn(true)->shouldBeCalled();
         $userAuthenticator->authenticate('root', 'p')->willReturn($user)->shouldBeCalled();
         $request->request('scope')->willReturn(null)->shouldBeCalled();
-        $client->getScopes()->willReturn([])->shouldBeCalled();
+        $user->getScopes()->willReturn([])->shouldBeCalled();
         $scopeResolver->getDefaultScopes()->willReturn([$scope])->shouldBeCalled();
         $scopeResolver->intersect(null, [$scope])->willReturn([$scope])->shouldBeCalled();
         $accessTokenStorage->generate($user, $client, [$scope])->willReturn($accessToken)->shouldBeCalled();

--- a/src/OAuth2/GrantType/AAuthorizationGrantType.php
+++ b/src/OAuth2/GrantType/AAuthorizationGrantType.php
@@ -9,6 +9,7 @@ use OAuth2\Exception\UnauthorizedClientException;
 use OAuth2\Http\IRequest;
 use OAuth2\Resolver\IScopeResolver;
 use OAuth2\Storage\IClientStorage;
+use OAuth2\Storage\IUser;
 
 /**
  * @author Michal Kvasničák <michal.kvasnicak@mink.sk>
@@ -39,14 +40,16 @@ abstract class AAuthorizationGrantType implements IAuthorizationGrantType
      *
      * @param IRequest $request
      *
-     * @return array
+     * @param IUser $user
      *
      * @throws \OAuth2\Exception\InvalidClientException
      * @throws \OAuth2\Exception\InvalidRequestException
      * @throws \OAuth2\Exception\InvalidScopeException
      * @throws \OAuth2\Exception\UnauthorizedClientException
+     * @return array
+     *
      */
-    protected function parseAuthorizationRequest(IRequest $request)
+    protected function parseAuthorizationRequest(IRequest $request, IUser $user)
     {
         $clientId = $request->query('client_id');
 
@@ -88,7 +91,7 @@ abstract class AAuthorizationGrantType implements IAuthorizationGrantType
         }
 
         $requestedScopes = $request->query('scope');
-        $availableScopes = $client->getScopes();
+        $availableScopes = $user->getScopes();
 
         if (!$availableScopes) {
             $availableScopes = $this->scopeResolver->getDefaultScopes();

--- a/src/OAuth2/GrantType/AuthorizationCode.php
+++ b/src/OAuth2/GrantType/AuthorizationCode.php
@@ -66,7 +66,7 @@ class AuthorizationCode extends AAuthorizationGrantType
      */
     public function authorize(IRequest $request, IUser $user)
     {
-        $requirements = parent::parseAuthorizationRequest($request);
+        $requirements = parent::parseAuthorizationRequest($request, $user);
 
         // redirect uri is without authorization code!
         $authorizationCode = $this->authorizationCodeStorage->generate(

--- a/src/OAuth2/GrantType/Implicit.php
+++ b/src/OAuth2/GrantType/Implicit.php
@@ -55,7 +55,7 @@ class Implicit extends AAuthorizationGrantType
      */
     public function authorize(IRequest $request, IUser $user)
     {
-        $requirements = parent::parseAuthorizationRequest($request);
+        $requirements = parent::parseAuthorizationRequest($request, $user);
 
         $accessToken = $this->accessTokenStorage->generate(
             $user,

--- a/src/OAuth2/GrantType/ResourceOwnerPasswordCredentials.php
+++ b/src/OAuth2/GrantType/ResourceOwnerPasswordCredentials.php
@@ -99,7 +99,7 @@ class ResourceOwnerPasswordCredentials implements IGrantType
         }
 
         $requestedScopes = $request->request('scope');
-        $availableScopes = $client->getScopes();
+        $availableScopes = $user->getScopes();
 
         if (empty($availableScopes)) {
             $availableScopes = $this->scopeResolver->getDefaultScopes();
@@ -109,6 +109,7 @@ class ResourceOwnerPasswordCredentials implements IGrantType
             throw new InvalidScopeException('Scope parameter has to be specified.');
         }
 
+        // intersection of requested and user scopes
         $scopes = $this->scopeResolver->intersect($requestedScopes, $availableScopes);
 
         return $this->accessTokenStorage->generate(

--- a/src/OAuth2/Storage/IUser.php
+++ b/src/OAuth2/Storage/IUser.php
@@ -8,4 +8,12 @@ namespace OAuth2\Storage;
 interface IUser 
 {
 
+
+    /**
+     * Gets user assigned scopes
+     *
+     * @return IScope[]
+     */
+    public function getScopes();
+
 }

--- a/tests/OAuth2/AuthorizationCodeGrantTypeTest.php
+++ b/tests/OAuth2/AuthorizationCodeGrantTypeTest.php
@@ -32,7 +32,7 @@ class AuthorizationCodeGrantTypeTest extends OAuth2GrantTypeTestCase
                 'public',
                 null,
                 [$authorizationCodeGrantType],
-                [new Scope('public')],
+                [],
                 null,
                 'http://google.com'
             )
@@ -42,7 +42,7 @@ class AuthorizationCodeGrantTypeTest extends OAuth2GrantTypeTestCase
                 'confidential',
                 'secret',
                 [$authorizationCodeGrantType],
-                [new Scope('confidential')],
+                [],
                 null,
                 'http://google.com'
             )
@@ -63,7 +63,7 @@ class AuthorizationCodeGrantTypeTest extends OAuth2GrantTypeTestCase
         );
 
         // request authorization from user
-        $session = $this->getAuthorizator()->authorize($request, $user = new User());
+        $session = $this->getAuthorizator()->authorize($request, $user = new User('', '', [new Scope('edit')]));
 
         $this->assertInstanceOf(
             'OAuth2\Security\AuthorizationCodeSession',

--- a/tests/OAuth2/Fixtures/User.php
+++ b/tests/OAuth2/Fixtures/User.php
@@ -20,11 +20,15 @@ class User implements IUser
      */
     private $password;
 
+    /** @var array  */
+    private $scopes = [];
 
-    public function __construct($username = null, $password = null)
+
+    public function __construct($username = null, $password = null, array $scopes = [])
     {
         $this->username = $username;
         $this->password = $password;
+        $this->scopes = $scopes;
     }
 
 
@@ -37,6 +41,12 @@ class User implements IUser
     public function getPassword()
     {
         return $this->password;
+    }
+
+
+    public function getScopes()
+    {
+        return $this->scopes;
     }
 
 }

--- a/tests/OAuth2/ImplicitGrantTypeTest.php
+++ b/tests/OAuth2/ImplicitGrantTypeTest.php
@@ -33,7 +33,7 @@ class ImplicitGrantTypeTest extends OAuth2GrantTypeTestCase
                 'public',
                 null,
                 [$implicitGrantType],
-                [new Scope('public'), new Scope('confidential')],
+                [],
                 null,
                 'http://google.com'
             )
@@ -54,7 +54,7 @@ class ImplicitGrantTypeTest extends OAuth2GrantTypeTestCase
         );
 
         // request authorization from user
-        $session = $this->getAuthorizator()->authorize($request, $user = new User());
+        $session = $this->getAuthorizator()->authorize($request, $user = new User('', '', [new Scope('edit'), new Scope('read')]));
 
         $this->assertInstanceOf('OAuth2\Security\ImplicitSession', $session);
         $this->assertInstanceOf('OAuth2\Security\IAuthorizationSession', $session);
@@ -63,7 +63,7 @@ class ImplicitGrantTypeTest extends OAuth2GrantTypeTestCase
         $this->assertInstanceOf('OAuth2\Storage\IClient', $session->getClient());
         $this->assertEquals('pom', $session->getState());
         $this->assertNotEmpty($session->getScopes());
-        $this->assertRegExp('~^http://google.com#access_token=(\w+)&expires_in=\d+&scope=public\+confidential&state=pom&token_type=Bearer$~', $session->getRedirectUri());
+        $this->assertRegExp('~^http://google.com#access_token=(\w+)&expires_in=\d+&scope=edit\+read&state=pom&token_type=Bearer$~', $session->getRedirectUri());
     }
 
 }


### PR DESCRIPTION
Grant types: authorization code, implicit and resource owner password credentials are working with user scopes and not client scopes. Because using this grant types you can access resource as an user, so you have to have his access privileges (scope) and not client's. 
